### PR TITLE
GEB-244 Fix

### DIFF
--- a/src/groovy/grails/plugin/greenmail/GreenMail.groovy
+++ b/src/groovy/grails/plugin/greenmail/GreenMail.groovy
@@ -44,6 +44,10 @@ class GreenMail extends com.icegreen.greenmail.util.GreenMail {
 		super.start()
 	}
 	
+	synchronized void stop() {
+		services.each { Service service -> service.stopService(stopTimeout) }
+	}
+	
 	void deleteAllMessages() {
 		managers.imapHostManager.store.listMailboxes('*')*.deleteAllMessages()
 	}


### PR DESCRIPTION
This gets even stranger, the JVM stops successfully if you simply copy the same code (I've improved it slightly to be groovier) that is done in the GreenMail.stop method into the plugin's groovy version that extends the actual GreenMail class.  As long as you don't call the actual GreenMail stop method, it all works as expected.
