### PR TITLE
GPGREENMAIL-13 Fixed silently failing bug is stop()

### DIFF
--- a/src/groovy/grails/plugin/greenmail/GreenMail.groovy
+++ b/src/groovy/grails/plugin/greenmail/GreenMail.groovy
@@ -46,7 +46,7 @@ class GreenMail extends com.icegreen.greenmail.util.GreenMail {
 	}
 	
 	synchronized void stop() {
-		services.each { Service service -> service.stopService(stopTimeout) }
+		super.stop()
 	}
 	
 	void deleteAllMessages() {


### PR DESCRIPTION
The `GreenMail.stop()` method was simply wrong causing the server not to stop. This is a major issue for continuous builds as `grails test-app` effectively fails with `BindException`. The problem was three-fold. The `stopTimeout` variable was not defined. The bean's destroy method seems to fail silently in that case (although I am still puzzled how it compiles). In addition the original GreenMail package doesn't provide any service stopping method that only takes timeout. There is `Object` (probably meant to provide a way for passing additional attributes) and timeout, or just `Object`. Third, the `super.stop()` does exactly the same iteration thru services stopping them. So simple `super.stop()` is a proper fix for all of the above.
