### PR TITLE
Remove overriding of stop method

### DIFF
--- a/src/main/groovy/grails/plugin/greenmail/GreenMail.groovy
+++ b/src/main/groovy/grails/plugin/greenmail/GreenMail.groovy
@@ -44,10 +44,6 @@ class GreenMail extends com.icegreen.greenmail.util.GreenMail {
 		super.start()
 	}
 	
-	synchronized void stop() {
-		services.each { Service service -> service.stopService(stopTimeout) }
-	}
-	
 	void deleteAllMessages() {
 		managers.imapHostManager.store.listMailboxes('*')*.deleteAllMessages()
 	}


### PR DESCRIPTION
I was getting the following error in my application:
groovy.lang.MissingPropertyException: No such property: services for class: grails.plugin.greenmail.GreenMail

Looking closer I see that the stop method here was referencing the property 'services' which is private to the parent class com.icegreen.greenmail.util.GreenMail.
Also 'stopTimeout' was undefined.

Looking at the parent's stop method, it looked adequate so  I do not see the rationale to keep this method overridden.

Parent's stop method:
`    @Override
    public synchronized void stop() {
        if (services != null) {
            for (Service service : services.values()) {
                if (service.isRunning()) {
                    service.stopService(null);
                }
            }
        }
        managers = new Managers();
        services = null;
    }`