### PR TITLE
Allow users to override the startup timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,16 @@ The plugin assumes that you have some sort of Java mail provider installed (for 
 	    }
 	}
 
-You can also completely disable the plugin by using the config setting `greenmail.disabled = true`.  For example, to disable greenmail in production:
+You can also completely disable the plugin by using the config setting `grails.plugin.greenmail.disabled = true`.  For example, to disable greenmail in production:
 
 	environments {
 	    production {
-	       greenmail.disabled=true
+	       grails.plugin.greenmail.disabled = true
 	    }
 	}
 
+If you are experiencing timeouts when the application is starting greenmail you can increase this setting (in ms) from 
+the config as follows: `grails.plugin.greenmail.serverStartupTimeout = 2000`
 
 ### Usage in Integration Tests
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 }
 
-version "2.0.0.RC3"
+version "2.0.1"
 group "org.grails.plugins"
 
 apply plugin:"eclipse"
@@ -24,9 +24,6 @@ ext {
     grailsVersion = project.grailsVersion
     gradleWrapperVersion = project.gradleWrapperVersion
 }
-
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
 
 repositories {
     mavenLocal()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=3.1.12
-gradleWrapperVersion=2.13
+grailsVersion=3.2.3
+gradleWrapperVersion=3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 27 23:09:32 CET 2015
+#Fri Feb 10 13:09:21 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip

--- a/src/main/groovy/grails/plugin/greenmail/GreenmailGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/greenmail/GreenmailGrailsPlugin.groovy
@@ -37,17 +37,19 @@ class GreenmailGrailsPlugin extends Plugin {
 	def profiles = ['web']
 
 	@Override
-	Closure doWithSpring() { {->
-			if (!config.getProperty("grails.plugin.greenmail.disabled", Boolean, false)){
-				int smtpPort = config.getProperty("grails.plugin.greenmail.ports.smtp", Integer, ServerSetupTest.SMTP.port) 
-				ServerSetup smtp = new ServerSetup(smtpPort, null, "smtp")
+	Closure doWithSpring() {
+        { ->
+            if (!config.getProperty("grails.plugin.greenmail.disabled", Boolean, false)) {
+                int smtpPort = config.getProperty("grails.plugin.greenmail.ports.smtp", Integer, ServerSetupTest.SMTP.port)
+                ServerSetup smtp = new ServerSetup(smtpPort, null, "smtp")
+                Long startupTimeout = config.getProperty("grails.plugin.greenmail.serverStartupTimeout", Long, 1000L)
+                smtp.serverStartupTimeout = startupTimeout
 
-				greenMail(GreenMail, [smtp] as ServerSetup[]) {
-					it.initMethod = 'start'
-					it.destroyMethod = 'stop'
-				}
+                greenMail(GreenMail, [smtp] as ServerSetup[]) {
+                    it.initMethod = 'start'
+                    it.destroyMethod = 'stop'
+                }
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
On slower machines the one second startup timeout can sometimes not be
enough. This was fixed in the 1.5.3 Greenmail release (which this
project was recently upgraded to). This commit seeks to expose this new
functionality to the grails plugin configuration. It also corrects some
of the outdated information on the README as well as upgrades the plugin to Grails 3.2.3.

Finally, I removed the RC status. I have been using this in a Grails 3 project since the beginning of last summer so not clear why we cannot move to 2.0.1 or the like.