### PR TITLE
Updated documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,22 @@ The plugin assumes that you have some sort of Java mail provider installed (for 
 	    }
 	}
 
-You can also completely disable the plugin by using the config setting `greenmail.disabled = true`.  For example, to disable greenmail in production:
+You can also completely disable the plugin by using the config setting `grails.plugin.greenmail.disabled = true`.  For example, to disable greenmail in production:
 
 	environments {
 	    production {
-	       greenmail.disabled=true
+	       grails.plugin.greenmail.disabled=true
 	    }
 	}
+
+If you need to change the default listening port (1025) you can use the `grails.plugin.greenmail.ports.smtp` configuration variable. For example: 
+
+	environments {
+	    test {
+	       grails.plugin.greenmail.ports.smtp = 2025
+	    }
+	}
+
 
 
 ### Usage in Integration Tests


### PR DESCRIPTION
 Config variable greenmail.disabled was incorrectly documented. 
Also, added doc for greenmail.ports.smtp config variable