### PR TITLE
Fix exposing /greenmail endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 jdk:
-- oraclejdk7
+- openjdk8
 before_script:
 - rm -rf target
 script: ./travis-build.sh

--- a/grails-app/controllers/greenmail/GreenmailUrlMappings.groovy
+++ b/grails-app/controllers/greenmail/GreenmailUrlMappings.groovy
@@ -1,0 +1,12 @@
+package greenmail
+
+import grails.util.Holders
+
+class GreenmailUrlMappings {
+
+    static mappings = {
+        if (!Holders.grailsApplication.config.getProperty("grails.plugin.greenmail.disabled", Boolean, false)) {
+            "/greenmail/$action?/$id?(.$format)?"(controller: 'greenmail')
+        }
+    }
+}

--- a/grails-app/init/greenmail/BootStrap.groovy
+++ b/grails-app/init/greenmail/BootStrap.groovy
@@ -1,3 +1,5 @@
+package greenmail
+
 class BootStrap {
 
     def init = { servletContext ->


### PR DESCRIPTION
This PR adds a `UrlMappings` to automatically expose the `/greenmail` endpoint only when the plugin is enabled (per the config).

This is a bit safer since:
- it does not rely on an application's `UrlMappings` to expose the endpoint
- it disables the access to the endpoint when the plugin is disabled (provided that the application using the plugin does not define the url mapping itself)

I also moved the `BootStrap` class into the `greenmail` package to avoid a `WARN` log about using the default root package at application start time (since Grails 3.2).

By the way, I have been able to make it successfully run with a new Grails 4.0.0 app.

Fixes #27 