### PR TITLE
Fix JSON output and null header prefix in GreenmailController

### DIFF
--- a/docs/src/docs/releaseNotes.adoc
+++ b/docs/src/docs/releaseNotes.adoc
@@ -2,7 +2,9 @@
 == Release Notes
 
 * 7.0.2 - Migrated to the `grails-plugin-template` build structure; guard against starting the
-  GreenMail server twice when the application context is refreshed
+  GreenMail server twice when the application context is refreshed; the `.json` extension on
+  `/greenmail/list` and `/greenmail/show/$id` now returns JSON instead of falling back to the HTML
+  view, and `/greenmail/show/$id` no longer prefixes the message headers with `null`
 * 7.0.1 - Package the precompiled GSP view so the `/greenmail` list renders in consuming applications
 * 7.0.0 - Support for Grails 7, Jakarta Mail and GreenMail 2.x
 * 5.0.0 - Support for Grails 5

--- a/docs/src/docs/releaseNotes.adoc
+++ b/docs/src/docs/releaseNotes.adoc
@@ -4,7 +4,8 @@
 * 7.0.2 - Migrated to the `grails-plugin-template` build structure; guard against starting the
   GreenMail server twice when the application context is refreshed; the `.json` extension on
   `/greenmail/list` and `/greenmail/show/$id` now returns JSON instead of falling back to the HTML
-  view, and `/greenmail/show/$id` no longer prefixes the message headers with `null`
+  view, `/greenmail/show/$id` no longer prefixes the message headers with `null`, and the `id` field
+  of `/greenmail/show/$id.json` is now a number, matching `/greenmail/list.json`
 * 7.0.1 - Package the precompiled GSP view so the `/greenmail` list renders in consuming applications
 * 7.0.0 - Support for Grails 7, Jakarta Mail and GreenMail 2.x
 * 5.0.0 - Support for Grails 5

--- a/docs/src/docs/usage/webInterface.adoc
+++ b/docs/src/docs/usage/webInterface.adoc
@@ -30,17 +30,17 @@ The following URLs are mapped:
 [[webInterface-json]]
 ==== JSON output
 
-Append a `.js` extension to get the captured messages as JSON, which is handy for scripted checks:
+Append a `.json` extension to `list` or `show` to get the captured messages as JSON, which is handy
+for scripted checks:
 
 ----
-http://localhost:8080/greenmail/list.js
+http://localhost:8080/greenmail/list.json
+http://localhost:8080/greenmail/show/0.json
 ----
 
-That responds with `application/json` and a list of objects carrying `id`, `sent`, `subject`, `to`
-and `body`.
+Both respond with `application/json`. `list.json` returns a list of objects carrying `id`, `sent`,
+`subject`, `to` and `body`; `show/$id.json` returns a single such object.
 
-CAUTION: Use `.js`, not `.json`. The controller's `withFormat` block handles the `html` and `js`
-formats only, so a `.json` extension falls back to the first block and silently returns the HTML
-view with a `text/html` content type rather than JSON.
+NOTE: The `.js` extension returns the same JSON and is retained for backwards compatibility.
 
 When `grails.plugin.greenmail.disabled` is `true` these URL mappings are not installed.

--- a/examples/app1/src/integration-test/groovy/app1/GreenmailControllerSpec.groovy
+++ b/examples/app1/src/integration-test/groovy/app1/GreenmailControllerSpec.groovy
@@ -141,6 +141,9 @@ class GreenmailControllerSpec extends Specification {
         Map parsed = new JsonSlurper().parseText(response.body) as Map
         parsed.subject == 'shown json subject'
         parsed.to == 'to@example.com'
+
+        and: 'id is the numeric index, as it is in list.json, not the String path parameter'
+        parsed.id == 0
     }
 
     void 'GET /greenmail/clear empties the mailbox'() {

--- a/examples/app1/src/integration-test/groovy/app1/GreenmailControllerSpec.groovy
+++ b/examples/app1/src/integration-test/groovy/app1/GreenmailControllerSpec.groovy
@@ -2,6 +2,7 @@ package app1
 
 import grails.plugin.greenmail.GreenMail
 import grails.testing.mixin.integration.Integration
+import groovy.json.JsonSlurper
 import jakarta.mail.internet.MimeMessage
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.mail.javamail.JavaMailSender
@@ -73,9 +74,28 @@ class GreenmailControllerSpec extends Specification {
         !response.body.contains('grailsLayout:')
     }
 
-    void 'GET /greenmail/list.js returns the captured messages as JSON'() {
+    void 'GET /greenmail/list.json returns the captured messages as JSON'() {
         given:
         sendOne('json subject')
+
+        when:
+        Map response = get('/greenmail/list.json')
+
+        then:
+        response.status == 200
+        response.contentType?.contains('application/json')
+
+        and: 'the whole body parses, so nothing is appended after the JSON document'
+        List parsed = new JsonSlurper().parseText(response.body) as List
+        parsed.size() == 1
+        parsed[0].subject == 'json subject'
+        parsed[0].to == 'to@example.com'
+        parsed[0].id == 0
+    }
+
+    void 'GET /greenmail/list.js returns the same JSON as .json'() {
+        given: 'the .js extension predates .json support and has to keep working'
+        sendOne('js subject')
 
         when:
         Map response = get('/greenmail/list.js')
@@ -85,23 +105,9 @@ class GreenmailControllerSpec extends Specification {
         response.contentType?.contains('application/json')
 
         and:
-        response.text.contains('"subject":"json subject"')
-        response.text.contains('"to":"to@example.com"')
-    }
-
-    void 'the .json extension currently falls back to the HTML view'() {
-        given: 'the controller withFormat block handles html and js, but not json'
-        sendOne('fallback subject')
-
-        when:
-        Map response = get('/greenmail/list.json')
-
-        then: 'Grails falls back to the first format block, so HTML is returned'
-        response.status == 200
-        response.contentType?.contains('text/html')
-
-        and: 'the message is still listed, just rendered as HTML rather than JSON'
-        response.text.contains('fallback subject')
+        List parsed = new JsonSlurper().parseText(response.body) as List
+        parsed.size() == 1
+        parsed[0].subject == 'js subject'
     }
 
     void 'GET /greenmail/show/0 renders the raw message'() {
@@ -114,6 +120,27 @@ class GreenmailControllerSpec extends Specification {
         then:
         response.status == 200
         response.text.contains('shown subject')
+
+        and: 'the headers are listed, and not prefixed with an uninitialised null'
+        !response.body.startsWith('null')
+        response.body.contains('Subject: shown subject<br/>')
+    }
+
+    void 'GET /greenmail/show/0.json returns the message as JSON'() {
+        given:
+        sendOne('shown json subject')
+
+        when:
+        Map response = get('/greenmail/show/0.json')
+
+        then:
+        response.status == 200
+        response.contentType?.contains('application/json')
+
+        and:
+        Map parsed = new JsonSlurper().parseText(response.body) as Map
+        parsed.subject == 'shown json subject'
+        parsed.to == 'to@example.com'
     }
 
     void 'GET /greenmail/clear empties the mailbox'() {

--- a/plugin/grails-app/controllers/com/piragua/greenmail/GreenmailController.groovy
+++ b/plugin/grails-app/controllers/com/piragua/greenmail/GreenmailController.groovy
@@ -29,41 +29,49 @@ class GreenmailController {
     def index() { redirect action: 'list' }
 
     def list() {
+        List<MimeMessage> messages = sortedMessages()
+        // Handed to both the js and json format blocks, so the two extensions render identically.
+        Closure renderAsJson = {
+            List jsonMessages = []
+            messages.eachWithIndex { message, index ->
+                jsonMessages << createMessageMap(message, index)
+            }
+            render(contentType: MimeType.JSON.name, text: new JsonBuilder(jsonMessages).toString())
+        }
         withFormat {
             html {
-                return [list: greenMail.getReceivedMessages().sort({ it.sentDate }).reverse()]
+                return [list: messages]
             }
-            js {
-                List jsonMessages = []
-                List<MimeMessage> messages = greenMail.getReceivedMessages().sort({ it.sentDate }).reverse().toList()
-                messages.eachWithIndex { message, index ->
-                    jsonMessages << createMessageMap(message, index)
-                }
-                render render(contentType: MimeType.JSON.name, text: new JsonBuilder(jsonMessages).toString())
-            }
+            js renderAsJson
+            json renderAsJson
         }
     }
 
     def show(String id) {
-        List<MimeMessage> messages = greenMail.getReceivedMessages().sort({ it.sentDate }).reverse().toList()
-        MimeMessage specificMessage = messages[Integer.valueOf(id).intValue()]
+        MimeMessage specificMessage = sortedMessages()[Integer.valueOf(id).intValue()]
+        Closure renderAsJson = {
+            render(contentType: MimeType.JSON.name, text: new JsonBuilder(createMessageMap(specificMessage, id)).toString())
+        }
         withFormat {
             html {
-                String header
-                specificMessage.getAllHeaders().each() {
+                String header = ''
+                specificMessage.getAllHeaders().each {
                     header += it.getName() + ': ' + it.getValue() + '<br/>'
                 }
                 render header + specificMessage.getContent()
             }
-            js {
-                render(contentType: MimeType.JSON.name, text: new JsonBuilder(createMessageMap(specificMessage, id)).toString())
-            }
+            js renderAsJson
+            json renderAsJson
         }
     }
 
     def clear() {
         greenMail.deleteAllMessages()
         render(contentType: MimeType.HTML.name) { div('Email messages have been cleared') }
+    }
+
+    private List<MimeMessage> sortedMessages() {
+        return greenMail.getReceivedMessages().sort({ it.sentDate }).reverse().toList()
     }
 
     private static createMessageMap(MimeMessage message, index) {

--- a/plugin/grails-app/controllers/com/piragua/greenmail/GreenmailController.groovy
+++ b/plugin/grails-app/controllers/com/piragua/greenmail/GreenmailController.groovy
@@ -48,9 +48,10 @@ class GreenmailController {
     }
 
     def show(String id) {
-        MimeMessage specificMessage = sortedMessages()[Integer.valueOf(id).intValue()]
+        int index = Integer.valueOf(id).intValue()
+        MimeMessage specificMessage = sortedMessages()[index]
         Closure renderAsJson = {
-            render(contentType: MimeType.JSON.name, text: new JsonBuilder(createMessageMap(specificMessage, id)).toString())
+            render(contentType: MimeType.JSON.name, text: new JsonBuilder(createMessageMap(specificMessage, index)).toString())
         }
         withFormat {
             html {
@@ -74,7 +75,7 @@ class GreenmailController {
         return greenMail.getReceivedMessages().sort({ it.sentDate }).reverse().toList()
     }
 
-    private static createMessageMap(MimeMessage message, index) {
+    private static Map createMessageMap(MimeMessage message, int index) {
         Map messageMap = [
                 id: index,
                 sent: message.sentDate,


### PR DESCRIPTION
Fixes four pre-existing defects in `GreenmailController`, all confirmed by the `examples/app1` integration tests added alongside the `grails-plugin-template` migration and deliberately left unfixed there to keep that change structural.

### `.json` did not return JSON

`list()` and `show()` handled the `html` and `js` formats only. `js` is `text/javascript`; `json` is a separate Grails mime type, so a `.json` request matched neither block and Grails fell back to the first (html) one — silently serving the HTML view with a `text/html` content type:

```
GET /greenmail/list.json    -> 200 text/html   (HTML view)
GET /greenmail/show/0.json  -> 200 text/html   (body starting with "null")
```

Both actions now handle `json` as well. The handler is a local `Closure` passed to both format names (`js renderAsJson` / `json renderAsJson`), so `.js` keeps working — it was the documented extension — without duplicating the body.

### `show()` prefixed the headers with `null`

`String header` was left uninitialised before `header += ...`, so every raw-message response began with the literal text `null`. Now initialised to `''`.

### Double `render` in the `js` branch of `list()`

`render render(contentType: ..., text: ...)` — the inner call already commits the response, so the outer one ran against its return value. Removed.

Note this one had **no observable symptom**: reintroducing it locally left all tests green, because the outer call is a silent no-op once the response is committed. It is a code-clarity fix, not a behaviour fix, and there is no regression test pinning it.

### `show/$id.json` serialised `id` as a String

`show(String id)` passed its String path parameter straight into `createMessageMap`, so the same message came back as `"id":0` from `list.json` but `"id":"0"` from `show/0.json`. The index is now parsed once into an `int` and reused for both the array lookup and the message map, and `createMessageMap` declares the parameter as `int` so an id cannot silently be serialised as a String again.

The `show/0.json` test asserts `parsed.id == 0`, which fails against the old String value.

### Incidental

The duplicated received-messages sort is factored into a private `sortedMessages()`, so `list()` sorts once and shares the result across its format blocks instead of re-fetching per branch.

## Tests

`GreenmailControllerSpec`:

- `'GET /greenmail/list.js returns the captured messages as JSON'` switched to `.json`
- `'the .json extension currently falls back to the HTML view'` — which pinned the wrong behaviour — replaced with a test that `.js` still returns the same JSON
- new `'GET /greenmail/show/0.json returns the message as JSON'`
- `'GET /greenmail/show/0 renders the raw message'` now asserts the body does not start with `null`
- the `show/0.json` test asserts `id` comes back as the number `0`

The JSON tests parse the whole response body with `JsonSlurper` rather than substring-matching, so trailing output would fail them.

## Docs

`usage/webInterface.adoc`: the CAUTION admonition telling users to prefer `.js` is replaced with a plain description of `.json` on both `list` and `show`, plus a NOTE that `.js` is retained for backwards compatibility. `releaseNotes.adoc`: the three user-visible fixes appended to the unreleased 7.0.2 entry.

## Verification

Green on JDK 17.0.18-librca (per `.sdkmanrc`): `./gradlew codeStyle` (zero CodeNarc/Checkstyle violations), `./gradlew :app1:integrationTest` (11 passing), plus `:greenmail:test` and `docs`.
