### PR TITLE
chore: sync verify-repository.groovy from grails-plugin-template

### DIFF
--- a/.github/scripts/verify-repository.groovy
+++ b/.github/scripts/verify-repository.groovy
@@ -187,7 +187,10 @@ if (sdkmanrcFile.exists()) {
         def distUrl = wrapperProps.getProperty('distributionUrl') ?: ''
         def m = distUrl =~ /gradle-([0-9.]+)-/
         if (m.find() && m.group(1) != sdkmanrc.getProperty('gradle')) {
-            err(".sdkmanrc gradle version ('${sdkmanrc.getProperty('gradle')}') does not match the wrapper's " +
+            // Dependabot's gradle-wrapper updates only touch
+            // gradle-wrapper.properties, never .sdkmanrc, so this drifts on
+            // every such PR by construction — a warning, not a hard error.
+            warn(".sdkmanrc gradle version ('${sdkmanrc.getProperty('gradle')}') does not match the wrapper's " +
                 "distributionUrl version ('${m.group(1)}')")
         }
     }


### PR DESCRIPTION
## Summary
- Manually syncs the `.sdkmanrc`/wrapper gradle-version-mismatch check from `err()` to `warn()`, matching grails-plugin-template's fix.
- This check was a hard error that fails by construction on every Dependabot gradle-wrapper bump PR, since Dependabot only touches `gradle-wrapper.properties`, never `.sdkmanrc` (hit in #52).
- Manual sync because the files-sync automation from grails-plugin-template isn't wired up in this repo yet.

Upstream fix: grails-plugins/grails-plugin-template#7

## Test plan
- [ ] `groovy .github/scripts/verify-repository.groovy` passes locally
- [ ] Verify Repository CI check passes on this PR